### PR TITLE
Update Grisbi runtime to 46

### DIFF
--- a/org.grisbi.Grisbi.yml
+++ b/org.grisbi.Grisbi.yml
@@ -1,6 +1,6 @@
 app-id: org.grisbi.Grisbi
 runtime: org.gnome.Platform
-runtime-version: "44"
+runtime-version: "46"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.gnome.Sdk.Locale


### PR DESCRIPTION
- Update Grisbi runtime to 46 since runtime version 44 has reached end-of-life.