### PR TITLE
Update the runtime version from 49 to 50, and more

### DIFF
--- a/org.grisbi.Grisbi.yml
+++ b/org.grisbi.Grisbi.yml
@@ -1,6 +1,6 @@
 app-id: org.grisbi.Grisbi
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.gnome.Sdk.Locale
@@ -20,6 +20,12 @@ finish-args:
 
 cleanup:
   - /include
+  - /lib/pkgconfig
+  - /share/doc/OpenSP
+  - /share/doc/libofx
+  - /share/gtk-doc
+  - /share/man
+  - '*.la'
   - '*.a'
 
 modules:


### PR DESCRIPTION
- Update the runtime version to 50
- Improve cleanup commands to reduce the Flatpak size
- Update the shared-modules